### PR TITLE
Updated references to the old domain and name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ GOOGLE_API_KEY=
 
 # The email configuration.
 EMAIL_DRIVER=log
-GLOBAL_ADMIN_EMAIL=global.admin@connectedtogether.org.uk
+GLOBAL_ADMIN_EMAIL=hlp.admin.connect@nhs.net
 
 # The Mailgun credentails.
 MAILGUN_DOMAIN=mg.connectedtogether.org.uk

--- a/app/Emails/OrganisationSignUpFormApproved/NotifySubmitterEmail.php
+++ b/app/Emails/OrganisationSignUpFormApproved/NotifySubmitterEmail.php
@@ -27,14 +27,14 @@ Your request to register ((ORGANISATION_NAME)) on Connected Together on ((REQUES
 
 Your service may not be visible on the site immediately due to the time it takes for our administration team to process new organisations.
 
-If you have any questions, please contact us at info@connectedtogether.org.uk.
+If you have any questions, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 
 You can now log on to the administration portal to update your page or add new services
-You will find more options to customise your page than were available on the completed form. You can access the administration portal at: admin.connectedtogether.org.uk
+You will find more options to customise your page than were available on the completed form. You can access the administration portal at: https://admin.connect.nhs.uk
 EOT;
     }
 

--- a/app/Emails/OrganisationSignUpFormReceived/NotifyGlobalAdminEmail.php
+++ b/app/Emails/OrganisationSignUpFormReceived/NotifyGlobalAdminEmail.php
@@ -28,7 +28,7 @@ Please review the request below before approving/rejecting:
 ((REQUEST_URL))
 
 Regards,
-Connected Together.
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/OrganisationSignUpFormReceived/NotifySubmitterEmail.php
+++ b/app/Emails/OrganisationSignUpFormReceived/NotifySubmitterEmail.php
@@ -24,11 +24,11 @@ Hi ((SUBMITTER_NAME)),
 
 Your request to register ((ORGANISATION_NAME)) on Connected Together has been submitted and received. A member of the admin team will review it shortly.
 
-If you have any questions, please get in touch at info@connectedtogether.org.uk.
+If you have any questions, please get in touch at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/OrganisationSignUpFormRejected/NotifySubmitterEmail.php
+++ b/app/Emails/OrganisationSignUpFormRejected/NotifySubmitterEmail.php
@@ -26,13 +26,13 @@ Thank you for submitting your request to have ((ORGANISATION_NAME)) listed on Co
 
 Unfortunately, your request to list ((ORGANISATION_NAME)) on Connected Together on ((REQUEST_DATE)) has been rejected. This is due to the organisation/service not meeting the terms and conditions of being listed on Connected Together.
 
-You can read more about our terms and conditions: https://www.connectedtogether.org.uk/terms-and-conditions
+You can read more about our terms and conditions: https://connect.nhs.uk/terms-and-conditions
 
-If you have any questions, please contact us at info@connectedtogether.org.uk.
+If you have any questions, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/PasswordReset/UserEmail.php
+++ b/app/Emails/PasswordReset/UserEmail.php
@@ -27,7 +27,7 @@ We have received a request to reset your password. Please follow this link:
 
 If this is not you, please ignore this message.
 
-If you need any further help please contact info@connectedtogether.org.uk
+If you need any further help please contact hlp.admin.connect@nhs.net
 EOT;
     }
 

--- a/app/Emails/ReferralCompleted/NotifyClientEmail.php
+++ b/app/Emails/ReferralCompleted/NotifyClientEmail.php
@@ -28,14 +28,11 @@ Your connection to ((SERVICE_NAME)) has been marked as completed by the service.
 
 This means that they have been in touch with you about accessing their service.
 
-If you have any feedback regarding this connection or believe the service did not try to contact you, please contact the admin team via info@connectedtogether.org.uk.
-
-Alternatively, you can complete the referral feedback form:
-https://docs.google.com/forms/d/e/1FAIpQLSe38Oe0vsqLRQbcBjYrGzMooBJKkYqFWAlHy4dcgwJnMFg9dQ/viewform?usp=pp_url&entry.400427747=((REFERRAL_ID))
+If you have any feedback regarding this connection or believe the service did not try to contact you, please contact the admin team via hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ReferralCompleted/NotifyRefereeEmail.php
+++ b/app/Emails/ReferralCompleted/NotifyRefereeEmail.php
@@ -26,14 +26,11 @@ The referral you made to ((SERVICE_NAME)) has been marked as complete. Referral 
 
 Your client should have been contacted by now, but if they haven’t then please contact them on ((SERVICE_PHONE)) or by email at ((SERVICE_EMAIL)).
 
-If you would like to leave any feedback on the referral or get in touch with us, you can contact us at info@connectedtogether.org.uk.
-
-Alternatively, you can complete our feedback form:
-https://docs.google.com/forms/d/e/1FAIpQLSe38Oe0vsqLRQbcBjYrGzMooBJKkYqFWAlHy4dcgwJnMFg9dQ/viewform?usp=pp_url&entry.400427747=((REFERRAL_ID)).
+If you would like to leave any feedback on the referral or get in touch with us, you can contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ReferralCreated/NotifyClientEmail.php
+++ b/app/Emails/ReferralCreated/NotifyClientEmail.php
@@ -28,14 +28,11 @@ They should be in touch with you via ((REFERRAL_CONTACT_METHOD)) within 10 worki
 
 Your referral ID is ((REFERRAL_ID)).
 
-If you have any feedback regarding this connection, or have not heard back within 10 working days, please contact the admin team via info@connectedtogether.org.uk.
-
-Alternatively, you can complete the referral feedback form:
-https://docs.google.com/forms/d/e/1FAIpQLSe38Oe0vsqLRQbcBjYrGzMooBJKkYqFWAlHy4dcgwJnMFg9dQ/viewform?usp=pp_url&entry.400427747=((REFERRAL_ID)).
+If you have any feedback regarding this connection, or have not heard back within 10 working days, please contact the admin team via hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ReferralCreated/NotifyRefereeEmail.php
+++ b/app/Emails/ReferralCreated/NotifyRefereeEmail.php
@@ -26,13 +26,11 @@ You’ve successfully made a referral to ((REFERRAL_SERVICE_NAME))!
 
 They should be in touch with the client by ((REFERRAL_CONTACT_METHOD)) to speak to them about accessing the service within 10 working days.
 
-The referral ID is ((REFERRAL_ID)). If you have any feedback regarding this connection, please contact the admin team via info@connectedtogether.org.uk.
-
-Alternatively, you can complete the referral feedback form: https://docs.google.com/forms/d/e/1FAIpQLSe38Oe0vsqLRQbcBjYrGzMooBJKkYqFWAlHy4dcgwJnMFg9dQ/viewform?usp=pp_url&entry.400427747=((REFERRAL_ID)).
+The referral ID is ((REFERRAL_ID)). If you have any feedback regarding this connection, please contact the admin team via hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ReferralCreated/NotifyServiceEmail.php
+++ b/app/Emails/ReferralCreated/NotifyServiceEmail.php
@@ -34,13 +34,13 @@ This is a ((REFERRAL_TYPE))
 Please contact the client via ((REFERRAL_CONTACT_METHOD)) within the next 10 working days.
 
 You can see further details of the referral, and mark as completed:
-http://admin.connectedtogether.org.uk/referrals
+http://admin.connect.nhs.uk/referrals
 
-If you have any questions, please contact us at info@connectedtogether.org.uk.
+If you have any questions, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ReferralIncompleted/NotifyClientEmail.php
+++ b/app/Emails/ReferralIncompleted/NotifyClientEmail.php
@@ -28,14 +28,11 @@ Your referral to ((SERVICE_NAME)) has been marked as incomplete with the followi
 
 “((REFERRAL_STATUS))“.
 
-If you believe the service did not try to contact you, or you have any other feedback regarding the connection, please contact us at info@connectedtogether.org.uk.
-
-Alternatively, you can complete our feedback form:
-https://docs.google.com/forms/d/e/1FAIpQLSe38Oe0vsqLRQbcBjYrGzMooBJKkYqFWAlHy4dcgwJnMFg9dQ/viewform?usp=pp_url&entry.400427747=((REFERRAL_ID))
+If you believe the service did not try to contact you, or you have any other feedback regarding the connection, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team.
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ReferralIncompleted/NotifyRefereeEmail.php
+++ b/app/Emails/ReferralIncompleted/NotifyRefereeEmail.php
@@ -26,14 +26,11 @@ The referral you made to ((SERVICE_NAME)) has been marked as incomplete with the
 
 “((REFERRAL_STATUS))“.
 
-If you believe the service did not try to contact the client, or you have any other feedback regarding the connection, please contact us at info@connectedtogether.org.uk.
-
-Alternatively, you can complete our feedback form:
-https://docs.google.com/forms/d/e/1FAIpQLSe38Oe0vsqLRQbcBjYrGzMooBJKkYqFWAlHy4dcgwJnMFg9dQ/viewform?usp=pp_url&entry.400427747=((REFERRAL_ID))
+If you believe the service did not try to contact the client, or you have any other feedback regarding the connection, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team.
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ReferralUnactioned/NotifyServiceEmail.php
+++ b/app/Emails/ReferralUnactioned/NotifyServiceEmail.php
@@ -39,13 +39,13 @@ Please contact the client via ((REFERRAL_CONTACT_METHOD)) within the next ((REFE
 If you are unable to get in contact with the client, you can mark the referral is ‘Incomplete’.
 
 You can update the status of the referral in the admin portal:
-http://admin.connectedtogether.org.uk/referrals
+http://admin.connect.nhs.uk/referrals
 
-If you have any questions, please contact us at info@connectedtogether.org.uk.
+If you have any questions, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 }

--- a/app/Emails/ServiceCreated/NotifyGlobalAdminEmail.php
+++ b/app/Emails/ServiceCreated/NotifyGlobalAdminEmail.php
@@ -40,7 +40,7 @@ To review the service, follow this link: ((SERVICE_URL))
 
 Many thanks,
 
-Connected Together
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/ServiceUpdatePrompt/NotifyServiceAdminEmail.php
+++ b/app/Emails/ServiceUpdatePrompt/NotifyServiceAdminEmail.php
@@ -30,8 +30,8 @@ View the page on Connected Together:
 Update Page
 You can login to our backend portal to update the page by entering your details and clicking the ‘Services’ tab. If you can’t remember your login, or need some additional support, feel free to contact the support team.
 
-Access the Connected Together backend portal to update:
-https://api.connectedtogether.org.uk/login
+Access the NHS Connect admim portal to update:
+https://api.connect.nhs.uk/login
 
 Page doesn’t need updating?
 Let us know:
@@ -42,16 +42,16 @@ We’ll make a note that the page is up to date already.
 Service no longer running?
 Please let us know if you’d like the page removed from the site. A member of our admin team will disable it for you.
 
-Contact us by email: info@connectedtogether.org.uk
+Contact us by email: hlp.admin.connect@nhs.net
 
 Don’t think you should have received this?
 You have received this because you are one of the admins for this page. If you believe this is incorrect, please let us know. We’ll be happy to change your permissions.
 
-Contact us by email: info@connectedtogether.org.uk
+Contact us by email: hlp.admin.connect@nhs.net
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/UpdateRequestApproved/NotifySubmitterEmail.php
+++ b/app/Emails/UpdateRequestApproved/NotifySubmitterEmail.php
@@ -24,11 +24,11 @@ Hi ((SUBMITTER_NAME)),
 
 Your update request for the ((RESOURCE_NAME)) (((RESOURCE_TYPE))) on ((REQUEST_DATE)) has been approved.
 
-If you have any questions, please contact us at info@connectedtogether.org.uk.
+If you have any questions, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/UpdateRequestReceived/NotifyGlobalAdminEmail.php
+++ b/app/Emails/UpdateRequestReceived/NotifyGlobalAdminEmail.php
@@ -28,7 +28,7 @@ Please review the request below before approving/rejecting:
 ((REQUEST_URL))
 
 Regards,
-Connected Together.
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/UpdateRequestReceived/NotifySubmitterEmail.php
+++ b/app/Emails/UpdateRequestReceived/NotifySubmitterEmail.php
@@ -24,11 +24,11 @@ Hi ((SUBMITTER_NAME)),
 
 Your update to ((RESOURCE_NAME)) (((RESOURCE_TYPE))) has been submitted and received. A member of the admin team will review it shortly.
 
-If you have any questions, please get in touch at info@connectedtogether.org.uk.
+If you have any questions, please get in touch at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/UpdateRequestRejected/NotifySubmitterEmail.php
+++ b/app/Emails/UpdateRequestRejected/NotifySubmitterEmail.php
@@ -24,11 +24,11 @@ Hi ((SUBMITTER_NAME)),
 
 Your update request for the ((RESOURCE_NAME)) (((RESOURCE_TYPE))) on ((REQUEST_DATE)) has been rejected.
 
-If you have any questions, please contact us at info@connectedtogether.org.uk.
+If you have any questions, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/UserCreated/NotifyUserEmail.php
+++ b/app/Emails/UserCreated/NotifyUserEmail.php
@@ -22,16 +22,16 @@ class NotifyUserEmail extends Email
         return <<<'EOT'
 Hi ((NAME)),
 
-An account has been created for you using this email address. You can log in to the Connected Together admin portal at:
-http://admin.connectedtogether.org.uk
+An account has been created for you using this email address. You can log in to the NHS Connect admin portal at:
+http://admin.connect.nhs.uk
 
 Permissions:
 ((PERMISSIONS))
 
-If you have any questions, you can email us at info@connectedtogether.org.uk
+If you have any questions, you can email us at hlp.admin.connect@nhs.net
 
 Many thanks,
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Emails/UserRolesUpdated/NotifyUserEmail.php
+++ b/app/Emails/UserRolesUpdated/NotifyUserEmail.php
@@ -30,11 +30,11 @@ Old permissions:
 New permissions:
 ((PERMISSIONS))
 
-If you have any questions, please contact us at info@connectedtogether.org.uk.
+If you have any questions, please contact us at hlp.admin.connect@nhs.net.
 
 Many thanks,
 
-The Connected Together team.
+NHS Connect Team 
 EOT;
     }
 

--- a/app/Sms/ReferralCompleted/NotifyClientSms.php
+++ b/app/Sms/ReferralCompleted/NotifyClientSms.php
@@ -20,7 +20,7 @@ class NotifyClientSms extends Sms
     public function getContent(): string
     {
         return <<<'EOT'
-Connected Together: You've made a connection on Connected Together ((REFERRAL_ID)). The service should contact you within 10 working days. Any feedback contact info@connectedtogether.org.uk
+Connected Together: You've made a connection on Connected Together ((REFERRAL_ID)). The service should contact you within 10 working days. Any feedback contact hlp.admin.connect@nhs.net
 EOT;
     }
 }

--- a/app/Sms/ReferralCompleted/NotifyRefereeSms.php
+++ b/app/Sms/ReferralCompleted/NotifyRefereeSms.php
@@ -27,7 +27,7 @@ The referral you made to ((SERVICE_NAME)) has been marked as complete. ID: ((REF
 Your client should have been contacted by now, but if they haven't then please contact them on ((SERVICE_PHONE)) or by email at ((SERVICE_EMAIL)).
 
 Regards,
-Connected Together.
+NHS Connect Team 
 EOT;
     }
 }

--- a/app/Sms/ReferralCreated/NotifyClientSms.php
+++ b/app/Sms/ReferralCreated/NotifyClientSms.php
@@ -20,7 +20,7 @@ class NotifyClientSms extends Sms
     public function getContent(): string
     {
         return <<<'EOT'
-Connected Together: You've made a connection on Connected Together ((REFERRAL_ID)). The service should contact you within 10 working days. Any feedback contact info@connectedtogether.org.uk
+Connected Together: You've made a connection on Connected Together ((REFERRAL_ID)). The service should contact you within 10 working days. Any feedback contact hlp.admin.connect@nhs.net
 EOT;
     }
 }

--- a/app/Sms/ReferralCreated/NotifyRefereeSms.php
+++ b/app/Sms/ReferralCreated/NotifyRefereeSms.php
@@ -20,7 +20,7 @@ class NotifyRefereeSms extends Sms
     public function getContent(): string
     {
         return <<<'EOT'
-Connected Together: You've made a connection for a client on Connected Together ((REFERRAL_ID)). The service should contact them within 10 working days. Any feedback contact info@connectedtogether.org.uk
+Connected Together: You've made a connection for a client on Connected Together ((REFERRAL_ID)). The service should contact them within 10 working days. Any feedback contact hlp.admin.connect@nhs.net
 EOT;
     }
 }

--- a/app/Sms/ReferralIncompleted/NotifyClientSms.php
+++ b/app/Sms/ReferralIncompleted/NotifyClientSms.php
@@ -24,9 +24,9 @@ Connected Together: Hi ((CLIENT_INITIALS)),
 
 Your referral (ID: ((REFERRAL_ID))) has been marked as incomplete. This means the service tried to contact you but couldn't.
 
-For details: info@connectedtogether.org.uk
+For details: hlp.admin.connect@nhs.net
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 }

--- a/app/Sms/ReferralIncompleted/NotifyRefereeSms.php
+++ b/app/Sms/ReferralIncompleted/NotifyRefereeSms.php
@@ -24,9 +24,9 @@ Connected Together: Hi ((REFEREE_NAME)),
 
 Your referral (ID: ((REFERRAL_ID))) has been marked as incomplete. This means the service tried to contact the client but couldn't.
 
-For details: info@connectedtogether.org.uk
+For details: hlp.admin.connect@nhs.net
 
-The Connected Together team
+NHS Connect Team 
 EOT;
     }
 }

--- a/config/mail.php
+++ b/config/mail.php
@@ -56,7 +56,7 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'noreply@connectedtogether.org.uk'),
+        'address' => env('MAIL_FROM_ADDRESS', 'hlp.admin.connect@nhs.net'),
         'name' => env('MAIL_FROM_NAME', 'Connected Together'),
     ],
 


### PR DESCRIPTION
- Replaces references to `connectedtogether.org.uk` in emails and SMS copy with `connect.nhs.uk`
- Updated the signature/sign-off in emails and SMS copy from `Connected Together team` to `NHS Connect Team`
- Removed Connected Kingston specific feedback form links in email copy