### PR TITLE
Feature/add link to organisation welcome email

### DIFF
--- a/app/Emails/OrganisationAdminInviteFirstFollowUps/NotifyInviteeEmail.php
+++ b/app/Emails/OrganisationAdminInviteFirstFollowUps/NotifyInviteeEmail.php
@@ -21,8 +21,8 @@ class NotifyInviteeEmail extends Email
     {
         return <<<'EOT'
 Dear ((ORGANISATION_NAME)),
-I’m writing to invite you to claim a listing for ((ORGANISATION_NAME)) on NHS Connect. 
-Your organisation has been recommended to us as an important source of support and we would like to add you to our new online directory as an early priority.  Your listing will then be accessible to citizens, to professionals supporting citizens (such as GPs or Link Workers), as well as to funders and commissioners. 
+I’m writing to invite you to claim a listing for ((ORGANISATION_NAME)) on NHS Connect.
+Your organisation has been recommended to us as an important source of support and we would like to add you to our new online directory as an early priority.  Your listing will then be accessible to citizens, to professionals supporting citizens (such as GPs or Link Workers), as well as to funders and commissioners.
 
 We currently have your organisation listed as:
 Address: ((ORGANISATION_ADDRESS))
@@ -32,17 +32,15 @@ Phone: ((ORGANISATION_PHONE))
 Social Media: ((ORGANISATION_SOCIAL_MEDIA))
 Description: ((ORGANISATION_DESCRIPTION))
 
-Click here to claim your listing:
-((INVITE_URL))
+<a href="((INVITE_URL))">Click here</a> to claim your listing.
 
 The Connect directory has been developed by the NHS to maximise everyone’s access to support for health and wellbeing. Adding a listing is completely free, improves your organisation’s profile, gives you access to new funding opportunities and above all ensures that the people who need your support most are able to access it.
 
-Not your organisation?  
-Our initial information is not always accurate and nothing you see here is made public until it is confirmed by you. If you want to add details for another organisation click here. 
-https://admin.connect.nhs.uk/register/
+Not your organisation?
+Our initial information is not always accurate and nothing you see here is made public until it is confirmed by you. If you want to add details for another organisation <a href="https://admin.connect.nhs.uk/register/">click here</a>.
 
-Having problems? 
-You can view some Frequently Asked Questions here
+Having problems?
+You can view some <a href="https://connect.nhs.uk/providers">Frequently Asked Questions here</a>.
 
 Many thanks for your help
 

--- a/app/Emails/OrganisationAdminInviteInitial/NotifyInviteeEmail.php
+++ b/app/Emails/OrganisationAdminInviteInitial/NotifyInviteeEmail.php
@@ -21,8 +21,8 @@ class NotifyInviteeEmail extends Email
     {
         return <<<'EOT'
 Dear ((ORGANISATION_NAME)),
-I’m writing to invite you to claim a listing for ((ORGANISATION_NAME)) on NHS Connect. 
-Your organisation has been recommended to us as an important source of support and we would like to add you to our new online directory as an early priority.  Your listing will then be accessible to citizens, to professionals supporting citizens (such as GPs or Link Workers), as well as to funders and commissioners. 
+I’m writing to invite you to claim a listing for ((ORGANISATION_NAME)) on NHS Connect.
+Your organisation has been recommended to us as an important source of support and we would like to add you to our new online directory as an early priority.  Your listing will then be accessible to citizens, to professionals supporting citizens (such as GPs or Link Workers), as well as to funders and commissioners.
 
 We currently have your organisation listed as:
 Address: ((ORGANISATION_ADDRESS))
@@ -32,17 +32,15 @@ Phone: ((ORGANISATION_PHONE))
 Social Media: ((ORGANISATION_SOCIAL_MEDIA))
 Description: ((ORGANISATION_DESCRIPTION))
 
-Click here to claim your listing:
-((INVITE_URL))
+<a href="((INVITE_URL))">Click here</a> to claim your listing.
 
-The Connect directory has been developed by the NHS to maximise everyone’s access to support for health and wellbeing. Adding a listing is completely free, improves your organisation’s profile, gives you access to new funding opportunities and above all ensures that the people who need your support most are able to access it. 
+The Connect directory has been developed by the NHS to maximise everyone’s access to support for health and wellbeing. Adding a listing is completely free, improves your organisation’s profile, gives you access to new funding opportunities and above all ensures that the people who need your support most are able to access it.
 
-Not your organisation?  
-Our initial information is not always accurate and nothing you see here is made public until it is confirmed by you. If you want to add details for another organisation click here. 
-https://admin.connect.nhs.uk/register/
+Not your organisation?
+Our initial information is not always accurate and nothing you see here is made public until it is confirmed by you. If you want to add details for another organisation <a href="https://admin.connect.nhs.uk/register/">click here</a>.
 
-Having problems? 
-You can view some Frequently Asked Questions here
+Having problems?
+You can view some <a href="https://connect.nhs.uk/providers">Frequently Asked Questions here</a>.
 
 Many thanks for your help
 

--- a/app/Emails/OrganisationAdminInviteSecondFollowUps/NotifyInviteeEmail.php
+++ b/app/Emails/OrganisationAdminInviteSecondFollowUps/NotifyInviteeEmail.php
@@ -21,8 +21,8 @@ class NotifyInviteeEmail extends Email
     {
         return <<<'EOT'
 Dear ((ORGANISATION_NAME)),
-We wrote to you five weeks ago to invite you to claim a listing for name of organisation on NHS Connect. 
-Your organisation was recommended to us as an important source of support and we would still very much like to add you to our new online directory. Your listing will then be accessible to citizens, to professionals supporting citizens (such as GPs or Link Workers), as well as to funders and commissioners. 
+We wrote to you five weeks ago to invite you to claim a listing for name of organisation on NHS Connect.
+Your organisation was recommended to us as an important source of support and we would still very much like to add you to our new online directory. Your listing will then be accessible to citizens, to professionals supporting citizens (such as GPs or Link Workers), as well as to funders and commissioners.
 Please help us protect the NHS by claiming your listing today.
 
 We currently have your organisation listed as:
@@ -33,18 +33,16 @@ Phone: ((ORGANISATION_PHONE))
 Social Media: ((ORGANISATION_SOCIAL_MEDIA))
 Description: ((ORGANISATION_DESCRIPTION))
 
-Click here to claim your listing:
-((INVITE_URL))
+<a href="((INVITE_URL))">Click here</a> to claim your listing.
 
 The Connect directory has been developed by the NHS to maximise everyone’s access to support for health and wellbeing. Adding a listing is completely free, improves your organisation’s profile, gives you access to new funding opportunities and above all ensures that the people who need your support most are able to access it.
 You have the ability to accept as many or as few new clients as you want, or even turn certain services off altogether.
 
-Not your organisation?  
-Our initial information is not always accurate and nothing you see here is made public until it is confirmed by you. If you want to add details for another organisation click here. 
-https://admin.connect.nhs.uk/register/
+Not your organisation?
+Our initial information is not always accurate and nothing you see here is made public until it is confirmed by you. If you want to add details for another organisation <a href="https://admin.connect.nhs.uk/register/">click here</a>.
 
-Having problems? 
-You can view some Frequently Asked Questions here
+Having problems?
+You can view some <a href="https://connect.nhs.uk/providers">Frequently Asked Questions here</a>.
 
 Many thanks for your help
 


### PR DESCRIPTION
### Summary
https://trello.com/c/IyJDJToR

Added anchor tags to linked items in Organisation Admin invite emails

### Development checklist
- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist
NA

### Notes
I was unable to test that the content of the emails is being rendered correctly. During QA the email contents should be viewed and the links tested.
