### PR TITLE
Dockerfile installs composer v1

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-add-repository -y ppa:ondrej/php \
     && apt-get update \
     && apt-get install -y php7.2-fpm php7.2-cli php7.2-gd php7.2-mysql php7.2-redis \
     php7.2-imap php7.2-mbstring php7.2-xml php7.2-curl php7.2-zip \
-    && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
+    && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --version=1.10.16 --filename=composer \
     && mkdir /run/php
 
 # Cleanup.


### PR DESCRIPTION
### Summary
https://trello.com/c/0yBZRwXe/200-use-compose-v1

Composer v2 has been released and is now the default version downloaded. We need to force a v1 install to prevent compatibility issues.

### Development checklist
- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist
N/A

### Notes
Once merged in, you may need to run` ./develop build` locally to install the specified composer version in the local Docker image.
