### PR TITLE
ServiceController::update updates category_taxonomies

### DIFF
--- a/app/Http/Controllers/Core/V1/ServiceController.php
+++ b/app/Http/Controllers/Core/V1/ServiceController.php
@@ -363,6 +363,12 @@ class ServiceController extends Controller
                 }
             }
 
+            // Update the category taxonomy records.
+            if ($request->filled('category_taxonomies')) {
+                $taxonomies = Taxonomy::whereIn('id', $request->category_taxonomies)->get();
+                $service->syncServiceTaxonomies($taxonomies);
+            }
+
             if ($request->filled('logo_file_id')) {
                 /** @var \App\Models\File $file */
                 $file = File::findOrFail($request->logo_file_id)->assigned();

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -1296,6 +1296,27 @@ class ServicesTest extends TestCase
         $response = $this->json('PUT', "/core/v1/services/{$service->id}", $payload);
 
         $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJsonFragment([
+            'category_taxonomies' => [
+                [
+                    'id' => $taxonomy->id,
+                    'parent_id' => $taxonomy->parent_id,
+                    'slug' => $taxonomy->slug,
+                    'name' => $taxonomy->name,
+                    'created_at' => $taxonomy->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $taxonomy->updated_at->format(CarbonImmutable::ISO8601),
+                ],
+                [
+                    'id' => $newTaxonomy->id,
+                    'parent_id' => $newTaxonomy->parent_id,
+                    'slug' => $newTaxonomy->slug,
+                    'name' => $newTaxonomy->name,
+                    'created_at' => $newTaxonomy->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $newTaxonomy->updated_at->format(CarbonImmutable::ISO8601),
+                ],
+            ],
+        ]);
     }
 
     public function test_global_admin_can_update_taxonomies()
@@ -1321,6 +1342,27 @@ class ServicesTest extends TestCase
         $response = $this->json('PUT', "/core/v1/services/{$service->id}", $payload);
 
         $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJsonFragment([
+            'category_taxonomies' => [
+                [
+                    'id' => $taxonomy->id,
+                    'parent_id' => $taxonomy->parent_id,
+                    'slug' => $taxonomy->slug,
+                    'name' => $taxonomy->name,
+                    'created_at' => $taxonomy->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $taxonomy->updated_at->format(CarbonImmutable::ISO8601),
+                ],
+                [
+                    'id' => $newTaxonomy->id,
+                    'parent_id' => $newTaxonomy->parent_id,
+                    'slug' => $newTaxonomy->slug,
+                    'name' => $newTaxonomy->name,
+                    'created_at' => $newTaxonomy->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $newTaxonomy->updated_at->format(CarbonImmutable::ISO8601),
+                ],
+            ],
+        ]);
     }
 
     public function test_service_admin_cannot_update_status()


### PR DESCRIPTION
### Summary
https://trello.com/c/Kuq68vts

- Updated tests to replicate the issue
- Update ServiceController::update looks for and updates category_taxonomies field

### Development checklist
- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist
NA

### Notes
NA
