### PR TITLE
Revert change to docker, expose app on port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/var/www/html
+    ports:
+      - "${APP_PORT}:80"
     depends_on:
       - mysql
       - redis


### PR DESCRIPTION
### Summary
No Trello ticket

In commit https://github.com/Healthy-London-Partnership/api/commit/40c7e93fdb4d4817b848a2a543accf9f255a8855#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3 the exposed port for app was removed from docker-compose.yml.

This prevented the app being available on my local docker install. I have therefore put the exposed port back. If this causes problems I can look at this again.

### Development checklist
- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist
NA

### Notes
NA
