### PR TITLE
Replaced class references in AppServiceProvider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,7 +22,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         // Use CarbonImmutable instead of Carbon.
-        Date::use (CarbonImmutable::class);
+        Date::use(CarbonImmutable::class);
 
         // Geocode.
         switch (config('hlp.geocode_driver')) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\RoleManagement\RoleChecker;
 use App\RoleManagement\RoleCheckerInterface;
 use App\RoleManagement\RoleManager;
 use App\RoleManagement\RoleManagerInterface;
+use App\VariableSubstitution\DoubleParenthesisVariableSubstituter;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\ServiceProvider;
@@ -21,7 +22,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         // Use CarbonImmutable instead of Carbon.
-        Date::use(CarbonImmutable::class);
+        Date::use (CarbonImmutable::class);
 
         // Geocode.
         switch (config('hlp.geocode_driver')) {
@@ -80,7 +81,7 @@ class AppServiceProvider extends ServiceProvider
         }
 
         // Variable substitution.
-        $this->app->bind(VariableSubstituter::class, DoubleParenthesisVariableSubstituter::class);
+        $this->app->bind(\App\Contracts\VariableSubstituter::class, DoubleParenthesisVariableSubstituter::class);
 
         // Admin URL generator.
         $this->app->singleton(AdminUrlGenerator::class, function () {


### PR DESCRIPTION
### Summary
NA

Emails were not being sent from production. The issue was tracked down to an exception returned from App\EmailSenders\MailgunEmailSender where VariableSubstituter could not be resolved.

This led to AppServiceProvider which had been altered during https://github.com/Healthy-London-Partnership/api/pull/39 with references to App\VariableSubstitution\DoubleParenthesisVariableSubstituter and App\Contracts\VariableSubstituter removed in error.

Once replaced and using a sandbox Mailgun domain, emails were once again being sent.

### Development checklist
- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist
NA

### Notes
NA
