### PR TITLE
Prevented SpreadsheetParser reading headers from empty cells

### DIFF
--- a/app/BatchUpload/SpreadsheetParser.php
+++ b/app/BatchUpload/SpreadsheetParser.php
@@ -112,7 +112,9 @@ class SpreadsheetParser
          * By default the cellIterator will only return populated cells.
          */
         foreach ($headerRow->getCellIterator() as $cell) {
-            $this->headers[$cell->getColumn()] = $cell->getValue();
+            if (trim($cell->getValue())) {
+                $this->headers[$cell->getColumn()] = $cell->getValue();
+            }
         }
 
         /**


### PR DESCRIPTION
### Summary
NA

Bulk upload of spreadsheet was failing with no visible errors. Traced it to an out of memory issue, which should not occur at the size of spreadsheet (~1k rows).

Investigating where the memory was being lost, found the SpreadsheetParser reading all columns in the sheet as headers so radically increasing the size of the import. Added test to readHeaders to check for empty cell contents, so only reading headers with text. This reduced the size and the spreadsheet can now import.

### Development checklist
- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist
NA

### Notes
NA
